### PR TITLE
Update Options.lua, Fix error on options dialog

### DIFF
--- a/Options.lua
+++ b/Options.lua
@@ -7,6 +7,7 @@ local icon = LibStub("LibDBIcon-1.0")
 local LSM = _G.LibStub:GetLibrary("LibSharedMedia-3.0")
 
 function CharacterNotes:GetOptions()
+  local options = {}
   if not self.options then
     options = {
       name = ADDON_NAME,


### PR DESCRIPTION
The options dialog is never shown, because options is not local. And so it mixes with other variables and an error occurs

52x ...nfig-3.0/AceConfigDialog-3.0-86/AceConfigDialog-3.0.lua:1854: AceConfigRegistry-3.0-21:ValidateOptionsTable(): Character Notes.HidePopup: unknown parameter
[string "=[C]"]: ?